### PR TITLE
Updated KDL tip frame to be tool0

### DIFF
--- a/snp_automate_2023/config/workcell_plugins.yaml
+++ b/snp_automate_2023/config/workcell_plugins.yaml
@@ -3,13 +3,13 @@ kinematic_plugins:
     - snp_motion_planning_plugins
   inv_kin_plugins:
     manipulator:
-      default: KDLInvKinChainLMA #IKFastInvKin
+      default: KDLInvKinChainLMA
       plugins:
         KDLInvKinChainLMA:
           class: KDLInvKinChainLMAFactory
           config:
             base_link: base_link
-            tip_link: tool_flange
+            tip_link: tool0
         IKFastInvKin:
           class: MotomanHC10InvKinFactory
           config:


### PR DESCRIPTION
Updates the KDL IK solver tip frame to be `tool0` such that other frames connected to `tool0` (e.g., `color_camera_optical_frame`) can be used as TCPs during motion planning. See [this comment](https://github.com/ros-industrial-consortium/snp_automate_2023/pull/12#issuecomment-2292216154) for more details