### PR TITLE
Update specification of MotoROS2 dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,10 @@ docker compose up
     source install/setup.bash
     ros2 launch snp_automate_2023 start.launch.xml sim_robot:=<true|false> sim_vision:=<true|false>
     ```
+
+## Hardware Configuration
+### MotoROS2
+
+Install MotoROS2 on the robot controller, following the [instructions on the MotoROS2 repository](https://github.com/Yaskawa-Global/motoros2?tab=readme-ov-file#installation).
+
+> Be sure to install the same version of MotoROS2 as the version of the `motoros2_interfaces` package defined in the [`dependencies.repos` file](dependencies.repos#L8).

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -5,11 +5,11 @@
 - git:
     local-name: motoros2_interfaces
     uri: https://github.com/yaskawa-global/motoros2_interfaces.git
-    version: main
+    version: 0.1.3
 - git:
     local-name: industrial_core_ros2_msgs_only
     uri: https://github.com/ros-industrial/industrial_core.git
-    version: ros2_msgs_only
+    version: d547cdcfdaf3bc0d46325215b8219b0a190c8e6c
 - git:
     local-name: motoros2_fjt_pt_queue_proxy
     uri: https://github.com/gavanderhoorn/motoros2_fjt_pt_queue_proxy.git


### PR DESCRIPTION
This PR updates the specification of the MotoROS2 dependencies to point to specific commits of the `motoros2_interfaces` and `industrial_msgs` packages to avoid conflicts caused by updates to these repositories, as reported in http://github.com/Yaskawa-Global/motoros2/discussions/393.

This PR also adds a note about ensuring that the MotoROS2 version matches the version of `motoros2_interfaces` for future reference.