### PR TITLE
Update `industrial_reconstruction` service BT nodes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,7 +56,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           build-args: |
-            TAG=@sha256:8612506d492fa7d66984639758c77386919e7e5782bce76a5874991b18c69aac
+            TAG=@sha256:6437400aadce8cb49acaedea314d809e06796cf2d80bba1fdd902e4ca95eba86
           push: ${{ env.PUSH_DOCKER_IMAGE }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,7 +56,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           build-args: |
-            TAG=@sha256:75c3f24fc1a561bd6a709d3efa2876ada80dc5ccd3c58597e526f00979a3e272
+            TAG=@sha256:8612506d492fa7d66984639758c77386919e7e5782bce76a5874991b18c69aac
           push: ${{ env.PUSH_DOCKER_IMAGE }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         distro: [humble]
     container:
-      image: ghcr.io/ros-industrial-consortium/scan_n_plan_workshop:@sha256:8612506d492fa7d66984639758c77386919e7e5782bce76a5874991b18c69aac
+      image: ghcr.io/ros-industrial-consortium/scan_n_plan_workshop@sha256:6437400aadce8cb49acaedea314d809e06796cf2d80bba1fdd902e4ca95eba86
       env:
         CCACHE_DIR: ${{ github.workspace }}/${{ matrix.distro }}/.ccache
         DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         distro: [humble]
     container:
-      image: ghcr.io/ros-industrial-consortium/scan_n_plan_workshop:@sha256:75c3f24fc1a561bd6a709d3efa2876ada80dc5ccd3c58597e526f00979a3e272
+      image: ghcr.io/ros-industrial-consortium/scan_n_plan_workshop:@sha256:8612506d492fa7d66984639758c77386919e7e5782bce76a5874991b18c69aac
       env:
         CCACHE_DIR: ${{ github.workspace }}/${{ matrix.distro }}/.ccache
         DEBIAN_FRONTEND: noninteractive

--- a/config/snp_automate.btproj
+++ b/config/snp_automate.btproj
@@ -97,14 +97,16 @@
             <input_port name="ref_frame" default="{reference_frame}"/>
             <input_port name="voxel_length" default="{ir_voxel_length}"/>
             <input_port name="sdf_trunc" default="{ir_sdf_trunc}"/>
+            <input_port name="depth_scale" default="{ir_depth_scale}"/>
+            <input_port name="depth_trunc" default="{ir_depth_trunc}"/>
+            <input_port name="translation_filter_distance" default="{ir_translation_filter_distance}"/>
+            <input_port name="rotation_filter_distance" default="{ir_rotation_filter_distance}"/>
             <input_port name="min_x" default="{ir_min_x}"/>
             <input_port name="min_y" default="{ir_min_y}"/>
             <input_port name="min_z" default="{ir_min_z}"/>
             <input_port name="max_x" default="{ir_max_x}"/>
             <input_port name="max_y" default="{ir_max_y}"/>
             <input_port name="max_z" default="{ir_max_z}"/>
-            <input_port name="depth_scale" default="{ir_depth_scale}"/>
-            <input_port name="depth_trunc" default="{ir_depth_trunc}"/>
             <input_port name="live_reconstruction" default="{ir_live}"/>
         </Action>
         <Action ID="StopReconstructionService" editable="true">

--- a/config/snp_automate.xml
+++ b/config/snp_automate.xml
@@ -243,14 +243,16 @@
                                   ref_frame="{reference_frame}"
                                   voxel_length="{ir_voxel_length}"
                                   sdf_trunc="{ir_sdf_trunc}"
+                                  depth_scale="{ir_depth_scale}"
+                                  depth_trunc="{ir_depth_trunc}"
+                                  translation_filter_distance="{ir_translation_filter_distance}"
+                                  rotation_filter_distance="{ir_rotation_filter_distance}"
                                   min_x="{ir_min_x}"
                                   min_y="{ir_min_y}"
                                   min_z="{ir_min_z}"
                                   max_x="{ir_max_x}"
                                   max_y="{ir_max_y}"
                                   max_z="{ir_max_z}"
-                                  depth_scale="{ir_depth_scale}"
-                                  depth_trunc="{ir_depth_trunc}"
                                   live_reconstruction="{ir_live}"/>
       <FollowJointTrajectoryAction name="Execute Scan Motion"
                                    action_name="{follow_joint_trajectory_action}"
@@ -433,6 +435,14 @@
                   default="{ir_voxel_length}"/>
       <input_port name="sdf_trunc"
                   default="{ir_sdf_trunc}"/>
+      <input_port name="depth_scale"
+                  default="{ir_depth_scale}"/>
+      <input_port name="depth_trunc"
+                  default="{ir_depth_trunc}"/>
+      <input_port name="translation_filter_distance"
+                  default="{ir_translation_filter_distance}"/>
+      <input_port name="rotation_filter_distance"
+                  default="{ir_rotation_filter_distance}"/>
       <input_port name="min_x"
                   default="{ir_min_x}"/>
       <input_port name="min_y"
@@ -445,10 +455,6 @@
                   default="{ir_max_y}"/>
       <input_port name="max_z"
                   default="{ir_max_z}"/>
-      <input_port name="depth_scale"
-                  default="{ir_depth_scale}"/>
-      <input_port name="depth_trunc"
-                  default="{ir_depth_trunc}"/>
       <input_port name="live_reconstruction"
                   default="{ir_live}"/>
     </Action>

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: ..
       dockerfile: docker/Dockerfile
       args:
-        - TAG=@sha256:75c3f24fc1a561bd6a709d3efa2876ada80dc5ccd3c58597e526f00979a3e272
+        - TAG=@sha256:8612506d492fa7d66984639758c77386919e7e5782bce76a5874991b18c69aac
     environment:
       DISPLAY: $DISPLAY
       XAUTHORITY: $XAUTHORITY

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: ..
       dockerfile: docker/Dockerfile
       args:
-        - TAG=@sha256:8612506d492fa7d66984639758c77386919e7e5782bce76a5874991b18c69aac
+        - TAG=@sha256:6437400aadce8cb49acaedea314d809e06796cf2d80bba1fdd902e4ca95eba86
     environment:
       DISPLAY: $DISPLAY
       XAUTHORITY: $XAUTHORITY

--- a/launch/start.launch.xml
+++ b/launch/start.launch.xml
@@ -53,6 +53,7 @@
     <param name="reference_frame" value="$(var reference_frame)"/>
     <param name="tcp_frame" value="sand_tcp"/>
     <param name="camera_frame" value="camera_color_optical_frame"/>
+    <param name="camera_tcp_frame" value="camera_color_optical_frame"/>
     <!-- Scan -->
     <param name="scan_trajectory_file" value="$(var scan_trajectory_file)"/>
     <param name="scan_motion_group" value="manipulator"/>

--- a/launch/start.launch.xml
+++ b/launch/start.launch.xml
@@ -66,15 +66,17 @@
     <!-- Industrial Reconstruction parameters -->
     <param name="ir_voxel_length" value="0.003"/>
     <param name="ir_sdf_trunc" value="0.015"/>
+    <param name="ir_depth_scale" value="1000.0"/>
+    <param name="ir_depth_trunc" value="0.9"/>
+    <param name="ir_translation_filter_distance" value="0.1"/>
+    <param name="ir_rotation_filter_distance" value="$(eval 'radians(5.0)')"/>
     <param name="ir_min_x" value="0.21"/>
     <param name="ir_min_y" value="-0.45"/>
     <param name="ir_min_z" value="0.0889"/>
     <param name="ir_max_x" value="1.5"/>
     <param name="ir_max_y" value="0.45"/>
     <param name="ir_max_z" value="0.527"/>
-    <param name="ir_depth_scale" value="1000.0"/>
-    <param name="ir_depth_trunc" value="0.9"/>
-    <param name="ir_live" value="true"/>
+    <param name="ir_live" value="false"/>
     <param name="ir_min_faces" value="3000"/>
     <param name="ir_normal_angle_tol" value="85.0"/>
     <param name="ir_normal_x" value="0.0"/>


### PR DESCRIPTION
The latest version of SNP exposes the translation/rotation distance "filters" in the industrial reconstruction `StartReconstruction` service, which require the camera to travel a specified distance before integrating new images. Through testing, we've found that setting these values to a non-zero number and disabling "live" reconstruction better controls the number of images integrated into the TSDF and results in a cleaner, higher quality mesh reconstruction.